### PR TITLE
safer compile?!

### DIFF
--- a/unix/Makefile
+++ b/unix/Makefile
@@ -29,15 +29,15 @@ all:	$(PRGS)
 again:	clean $(PRGS)
 
 lz4mt:
-	$(CC) $(CFLAGS) $(LDFLAGS) -llz4 -o $@ lz4mt.c $(LIBLZ4) $(COMMON)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ lz4mt.c $(LIBLZ4) $(COMMON) -llz4 
 	$(STRIP) $@
 
 lz5mt:
-	$(CC) $(CFLAGS) $(LDFLAGS) -llz5 -o $@ lz5mt.c $(LIBLZ5) $(COMMON)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ lz5mt.c $(LIBLZ5) $(COMMON) -llz5 
 	$(STRIP) $@
 
 zstdmt:
-	$(CC) $(CFLAGS) $(LDFLAGS) -lzstd -o $@ zstdmt.c $(LIBZSTD) $(COMMON)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ zstdmt.c $(LIBZSTD) $(COMMON) -lzstd 
 	$(STRIP) $@
 
 clean:

--- a/unix/util.h
+++ b/unix/util.h
@@ -11,6 +11,9 @@
  * - zstdmt source repository: https://github.com/mcmilk/zstdmt
  */
 
+#ifndef UTIL_H
+#define UTIL_H
+
 #define _FILE_OFFSET_BITS 64
 
 #include <unistd.h>
@@ -35,4 +38,6 @@ int open_rw(const char *filename);
 #else
 #  define IS_CONSOLE(stdStream) 0
 #endif
+
+#endif		/* UTIL_H */
 


### PR DESCRIPTION
1- Failed to compile ([gcc_fails.txt](https://github.com/mcmilk/zstdmt/files/699206/gcc_fails.txt)) on "xubuntu 4.4.0-31-generic SMP i686" and "gcc (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609" with "Undefined reference to " all ZSTD_XXXX reference functions.
Found a solution in:
http://stackoverflow.com/questions/10456581/undefined-reference-to-symbol-even-when-nm-indicates-that-this-symbol-is-present
by moving linker -lXXX to the end of compile line, problem solved on this case.

2- Adding Header Guard to "util.h" just seemed to be useful, as it's double defined in both "util.c"
and "zstdmt.c"/"lz4mt.c"/"lz5mt.c".

Thanks for this great work, really useful to me. 
