### PR TITLE
no error message given on non-zero exit status

### DIFF
--- a/programs/main.c
+++ b/programs/main.c
@@ -553,9 +553,10 @@ static void treat_stdin()
 		errmsg = do_decompress(fin, fout);
 
 	/* remember, that we had some error */
-	if (errmsg)
+	if (errmsg) {
+		fprintf(stderr, "%s: stdin: %s\n", progname, errmsg);
 		exit_code = E_ERROR;
-
+	}
 	/* listing mode */
 	if (opt_mode == MODE_LIST)
 		print_listmode(1, filename);
@@ -643,9 +644,10 @@ static void treat_file(char *filename)
 		errmsg = do_decompress(fin, local_fout);
 
 	/* remember, that we had some error */
-	if (errmsg)
+	if (errmsg) {
+		fprintf(stderr, "%s: %s: %s\n", progname, filename, errmsg);
 		exit_code = E_ERROR;
-
+	}
 	/* close instream */
 	if (fin && fin != stdin)
 		if (fclose(fin) != 0 && opt_verbose)


### PR DESCRIPTION
zstd-mt (and probably the commands as well) does not always give an error message where needed, even though it does have a non-zero exit status, e.g. where filename is not a zstd compressed file, the command
zstd-mt -v -k -d -c filename > /dev/null
should give the error:
zstd-mt: filename: Malformed input
but does not.
I made this patch to get running locally.