### PR TITLE
add snappy delete lz5 and update zstd

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,9 +2,7 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master ]
   pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Multithreading Library for [Brotli], [Lizard], [LZ4], [LZ5] and [Zstandard]
+# Multithreading Library for [Brotli], [Lizard], [LZ4], [LZ5], [Snappy] and [Zstandard]
 
 ## Description
 - works with skippables frame id 0x184D2A50 (12 bytes per compressed frame)
@@ -29,6 +29,17 @@ size    | value             | description
 2 bytes | 0x5242U           | magic for brotli "BR"
 2 bytes | uncompressed size | allocation hint for decompressor (64KB * this size)
 
+## [Snappy] frame definition
+
+- the frame header for Snappy is defined a bit different:
+
+size    | value             | description
+--------|-------------------|------------
+4 bytes | 0x184D2A50U       | magic for skippable frame (like zstd)
+4 bytes | 8                 | size of skippable frame
+4 bytes | compressed size   | size of the following frame (compressed data)
+2 bytes | 0x5053U           | magic for Snappy "SP"
+2 bytes | uncompressed size | allocation hint for decompressor (64KB * this size)
 
 ## Usage of the Testutils
 - see [programs](https://github.com/mcmilk/zstdmt/tree/master/programs)
@@ -43,6 +54,7 @@ size    | value             | description
 [LZ5]:https://github.com/inikep/lz5/
 [Zstandard]:https://github.com/facebook/zstd/
 [Lizard]:https://github.com/inikep/lizard/
+[Snappy]:https://github.com/google/snappy
 
 
 /TR 2017-05-24

--- a/lib/snappy-mt.h
+++ b/lib/snappy-mt.h
@@ -1,0 +1,146 @@
+/* ***************************************
+ * Defines
+ ****************************************/
+
+#ifndef SNAPPYMT_H
+#define SNAPPYMT_H
+
+#if defined (__cplusplus)
+extern "C" {
+#endif
+
+#include <stddef.h>   /* size_t */
+
+
+#define SNAPPYMT_THREAD_MAX 128
+#define SNAPPYMT_MAGICNUMBER 0x5053 // SP
+#define SNAPPYMT_MAGIC_SKIPPABLE 0x184D2A50U  // MT magic number
+
+/* **************************************
+ * Error Handling
+ ****************************************/
+
+typedef enum {
+  SNAPPYMT_error_no_error,
+  SNAPPYMT_error_memory_allocation,
+  SNAPPYMT_error_read_fail,
+  SNAPPYMT_error_write_fail,
+  SNAPPYMT_error_data_error,
+  SNAPPYMT_error_frame_compress,
+  SNAPPYMT_error_frame_decompress,
+  SNAPPYMT_error_compressionParameter_unsupported,
+  SNAPPYMT_error_compression_library,
+  SNAPPYMT_error_canceled,
+  SNAPPYMT_error_maxCode
+} SNAPPYMT_ErrorCode;
+
+#define PREFIX(name) SNAPPYMT_error_##name
+#define MT_ERROR(name)  ((size_t)-PREFIX(name))
+extern unsigned SNAPPYMT_isError(size_t code);
+extern const char* SNAPPYMT_getErrorString(size_t code);
+
+/* **************************************
+ * Structures
+ ****************************************/
+
+typedef struct {
+	void *buf;		/* ptr to data */
+	size_t size;		/* current filled in buf */
+	size_t allocated;	/* length of buf */
+} SNAPPYMT_Buffer;
+
+/**
+ * reading and writing functions
+ * - you can use stdio functions or plain read/write
+ * - just write some wrapper on your own
+ * - a sample is given in 7-Zip ZS or bromt.c
+ * - the function should return -1 on error and zero on success
+ * - the read or written bytes will go to in->size or out->size
+ */
+typedef int (fnRead) (void *args, SNAPPYMT_Buffer * in);
+typedef int (fnWrite) (void *args, SNAPPYMT_Buffer * out);
+
+typedef struct {
+	fnRead *fn_read;
+	void *arg_read;
+	fnWrite *fn_write;
+	void *arg_write;
+} SNAPPYMT_RdWr_t;
+
+/* **************************************
+ * Compression
+ ****************************************/
+
+typedef struct SNAPPYMT_CCtx_s SNAPPYMT_CCtx;
+
+/**
+ * 1) allocate new cctx
+ * - return cctx or zero on error
+ *
+ * @level   - 1 .. 9
+ * @threads - 1 .. BROTLIMT_THREAD_MAX
+ * @inputsize - if zero, becomes some optimal value for the level
+ *            - if nonzero, the given value is taken
+ */
+SNAPPYMT_CCtx *SNAPPYMT_createCCtx(int threads, int level,/*Not use*/ 
+                                   int inputsize);
+
+/**
+ * 2) threaded compression
+ * - errorcheck via 
+ */
+size_t SNAPPYMT_compressCCtx(SNAPPYMT_CCtx * ctx, SNAPPYMT_RdWr_t * rdwr);
+
+/**
+ * 3) get some statistic
+ */
+size_t SNAPPYMT_GetFramesCCtx(SNAPPYMT_CCtx * ctx);
+size_t SNAPPYMT_GetInsizeCCtx(SNAPPYMT_CCtx * ctx);
+size_t SNAPPYMT_GetOutsizeCCtx(SNAPPYMT_CCtx * ctx);
+
+/**
+ * 4) free cctx
+ * - no special return value
+ */
+void SNAPPYMT_freeCCtx(SNAPPYMT_CCtx * ctx);
+
+/* **************************************
+ * Decompression
+ ****************************************/
+
+typedef struct SNAPPYMT_DCtx_s SNAPPYMT_DCtx;
+
+/**
+ * 1) allocate new cctx
+ * - return cctx or zero on error
+ *
+ * @threads - 1 .. BROTLIMT_THREAD_MAX
+ * @ inputsize - used for single threaded standard bro format without 
+ *   skippable frames
+ */
+SNAPPYMT_DCtx *SNAPPYMT_createDCtx(int threads, int inputsize);
+
+/**
+ * 2) threaded compression
+ * - return -1 on error
+ */
+size_t SNAPPYMT_decompressDCtx(SNAPPYMT_DCtx * ctx, SNAPPYMT_RdWr_t * rdwr);
+
+/**
+ * 3) get some statistic
+ */
+size_t SNAPPYMT_GetFramesDCtx(SNAPPYMT_DCtx * ctx);
+size_t SNAPPYMT_GetInsizeDCtx(SNAPPYMT_DCtx * ctx);
+size_t SNAPPYMT_GetOutsizeDCtx(SNAPPYMT_DCtx * ctx);
+
+/**
+ * 4) free cctx
+ * - no special return value
+ */
+void SNAPPYMT_freeDCtx(SNAPPYMT_DCtx * ctx);
+
+#if defined (__cplusplus)
+}
+#endif
+
+#endif

--- a/lib/snappy-mt_common.cc
+++ b/lib/snappy-mt_common.cc
@@ -1,0 +1,44 @@
+
+#include "snappy-mt.h"
+
+/* ****************************************
+ * SNAPPY Error Management
+ ******************************************/
+
+/**
+ * SNAPPYMT_isError() - tells if a return value is an error code
+ */
+unsigned SNAPPYMT_isError(size_t code)
+{
+	return (code > MT_ERROR(maxCode));
+}
+
+/**
+ * SNAPPYMT_getErrorString() - give our error code string of result
+ */
+const char *SNAPPYMT_getErrorString(size_t code)
+{
+	static const char *noErrorCode = "Unspecified brotli error code";
+
+	switch ((SNAPPYMT_ErrorCode) (0 - code)) {
+	case PREFIX(no_error):
+		return "No error detected";
+	case PREFIX(memory_allocation):
+		return "Allocation error : not enough memory";
+	case PREFIX(read_fail):
+		return "Read failure";
+	case PREFIX(write_fail):
+		return "Write failure";
+	case PREFIX(data_error):
+		return "Malformed input";
+	case PREFIX(frame_compress):
+		return "Could not compress frame at once";
+	case PREFIX(frame_decompress):
+		return "Could not decompress frame at once";
+	case PREFIX(compressionParameter_unsupported):
+		return "Compression parameter is out of bound";
+	case PREFIX(maxCode):
+	default:
+		return noErrorCode;
+	}
+}

--- a/lib/snappy-mt_compress.cc
+++ b/lib/snappy-mt_compress.cc
@@ -1,0 +1,450 @@
+#include "../snappy/snappy-c.h"
+#include "snappy-mt.h"
+
+#include "memmt.h"
+#include "threading.h"
+#include "list.h"
+
+#include <iostream>
+#include <stdlib.h>
+#include <string.h>
+
+#define IN_ALLOC_SIZE (1024*1024)
+
+/**
+ * multi threaded snappy - multiple workers version
+ *
+ * - each thread works on his own
+ * - no main thread which does reading and then starting the work
+ * - needs a callback for reading / writing
+ * - each worker does his:
+ *   1) get read mutex and read some input
+ *   2) release read mutex and do compression
+ *   3) get write mutex and write result
+ *   4) begin with step 1 again, until no input
+ */
+
+typedef struct {
+	SNAPPYMT_CCtx *ctx;
+	pthread_t pthread;
+} cwork_t;
+
+struct writelist {
+	size_t frame;
+	SNAPPYMT_Buffer out;
+	struct list_head node;
+};
+
+
+struct SNAPPYMT_CCtx_s {
+
+	/* levels: 1..SNAPPYMT NOT USE  DELETE level maybe later*/
+	int level;
+
+	/* threads: 1..SNAPPYMT_THREAD_MAX */
+	int threads;
+
+	/* should be used for read from input */
+	int inputsize;
+
+	/* statistic */
+	size_t insize;
+	size_t outsize;
+	size_t curframe;
+	size_t frames;
+
+	/* threading */
+	cwork_t *cwork;
+
+	/* reading input */
+	pthread_mutex_t read_mutex;
+	fnRead *fn_read;
+	void *arg_read;
+
+	/* writing output */
+	pthread_mutex_t write_mutex;
+	fnWrite *fn_write;
+	void *arg_write;
+
+	/* lists for writing queue */
+	struct list_head writelist_free;
+	struct list_head writelist_busy;
+	struct list_head writelist_done;
+};
+
+/* **************************************
+ * Compression
+ ****************************************/
+
+SNAPPYMT_CCtx *SNAPPYMT_createCCtx(int threads, int level,/*Not use*/ 
+								   int inputsize)
+{
+	SNAPPYMT_CCtx *ctx;
+	int t;
+
+	/* allocate ctx */
+	ctx = (SNAPPYMT_CCtx *) malloc(sizeof(SNAPPYMT_CCtx));
+	if (!ctx)
+		return 0;
+
+	/* check threads value */
+	if (threads < 1 || threads > SNAPPYMT_THREAD_MAX)
+		return 0;
+
+	/* check level */
+	/* None level */
+
+	/* calculate chunksize for one thread */
+	if (inputsize)
+		ctx->inputsize = inputsize;
+	else
+		ctx->inputsize = 1024 * 64;  /* 64K frame */
+
+	/* setup ctx */
+	ctx->level = 0; 
+	ctx->threads = threads;
+	ctx->insize = 0;
+	ctx->outsize = 0;
+	ctx->frames = 0;
+	ctx->curframe = 0;
+
+	pthread_mutex_init(&ctx->read_mutex, NULL);
+	pthread_mutex_init(&ctx->write_mutex, NULL);
+
+	/* free -> busy -> out -> free -> ... */
+	INIT_LIST_HEAD(&ctx->writelist_free);	/* free, can be used */
+	INIT_LIST_HEAD(&ctx->writelist_busy);	/* busy */
+	INIT_LIST_HEAD(&ctx->writelist_done);	/* can be written */
+
+	ctx->cwork = (cwork_t *) malloc(sizeof(cwork_t) * threads);
+	if (!ctx->cwork)
+		goto err_cwork;
+
+	for (t = 0; t < threads; t++) {
+		cwork_t *w = &ctx->cwork[t];
+		w->ctx = ctx;
+	}
+
+	return ctx;
+
+ err_cwork:
+	free(ctx);
+
+	return nullptr;
+}
+
+/**
+ * mt_error - return mt lib specific error code read write ERROR
+ */
+static size_t mt_error(int rv)
+{
+	switch (rv) {
+	case -1:
+		return MT_ERROR(read_fail);
+	case -2:
+		return MT_ERROR(canceled);
+	case -3:
+		return MT_ERROR(memory_allocation);
+	}
+
+	return MT_ERROR(read_fail);
+}
+
+/**
+ * pt_write - queue for compressed output
+ */
+static size_t pt_write(SNAPPYMT_CCtx *ctx, struct writelist *wl)
+{
+	struct list_head *entry;
+
+	/* move the entry to the done list */
+	list_move(&wl->node, &ctx->writelist_done);
+
+	/* the entry isn't the currently needed, return...  */
+	if (wl->frame != ctx->curframe)
+		return 0;
+
+ again:
+	/* check, what can be written ... */
+	list_for_each(entry, &ctx->writelist_done) {
+		wl = list_entry(entry, struct writelist, node);
+		if (wl->frame == ctx->curframe) {
+			int rv = ctx->fn_write(ctx->arg_write, &wl->out);
+			if (rv != 0)
+				return mt_error(rv);
+			ctx->outsize += wl->out.size;
+			ctx->curframe++;
+			list_move(entry, &ctx->writelist_free);
+			goto again;
+		}
+	}
+
+	return 0;
+}
+
+static void *pt_compress(void *arg)
+{
+	cwork_t *w = (cwork_t *) arg;
+	SNAPPYMT_CCtx *ctx = w->ctx;
+	size_t result;
+	SNAPPYMT_Buffer in;
+
+	/* inbuf is constant */
+	in.size = ctx->inputsize;
+	in.buf = malloc(in.size);
+	if (!in.buf)
+		return (void *)MT_ERROR(memory_allocation);
+
+	for (;;) {
+		struct list_head *entry;
+		struct writelist *wl;
+		int rv;
+
+		/* allocate space for new output */
+		pthread_mutex_lock(&ctx->write_mutex);
+		if (!list_empty(&ctx->writelist_free)) {
+			/* take unused entry */
+			entry = list_first(&ctx->writelist_free);
+			wl = list_entry(entry, struct writelist, node);
+			wl->out.size =
+			    snappy_max_compressed_length(ctx->inputsize) + 16;
+			list_move(entry, &ctx->writelist_busy);
+		} else {
+			/* allocate new one */
+			wl = (struct writelist *)
+			    malloc(sizeof(struct writelist));
+			if (!wl) {
+				pthread_mutex_unlock(&ctx->write_mutex);
+				return (void *)MT_ERROR(memory_allocation);
+			}
+			wl->out.size =
+			    snappy_max_compressed_length(ctx->inputsize) + 16;
+			wl->out.buf = malloc(wl->out.size);
+			if (!wl->out.buf) {
+				pthread_mutex_unlock(&ctx->write_mutex);
+				return (void *)MT_ERROR(memory_allocation);
+			}
+			list_add(&wl->node, &ctx->writelist_busy);
+		}
+		pthread_mutex_unlock(&ctx->write_mutex);
+
+		/* read new input */
+		pthread_mutex_lock(&ctx->read_mutex);
+		in.size = ctx->inputsize;
+		rv = ctx->fn_read(ctx->arg_read, &in);
+		if (rv != 0) {
+			pthread_mutex_unlock(&ctx->read_mutex);
+			return (void *)mt_error(rv);
+		}
+
+		/* eof */
+		if (in.size == 0 && ctx->frames > 0) {
+			free(in.buf);
+			pthread_mutex_unlock(&ctx->read_mutex);
+
+			pthread_mutex_lock(&ctx->write_mutex);
+			list_move(&wl->node, &ctx->writelist_free);
+			pthread_mutex_unlock(&ctx->write_mutex);
+
+			goto okay;
+		}
+		ctx->insize += in.size;
+		wl->frame = ctx->frames++;
+		pthread_mutex_unlock(&ctx->read_mutex);
+
+		/* compress whole frame */
+		{
+			const char *ibuf = static_cast<char*>(in.buf);
+			char *obuf = static_cast<char*>(wl->out.buf) + 16;
+			wl->out.size -= 16;
+			rv = snappy_compress(ibuf, in.size, obuf, &wl->out.size);
+
+			/* printf("snappy_compress() rv=%d in=%zu out=%zu\n", rv, in.size, wl->out.size); */
+
+			if (rv != SNAPPY_OK) {
+				pthread_mutex_lock(&ctx->write_mutex);
+				list_move(&wl->node, &ctx->writelist_free);
+				pthread_mutex_unlock(&ctx->write_mutex);
+				return (void *)MT_ERROR(frame_compress);
+			}
+		}
+
+		/* write skippable frame */
+		MEM_writeLE32((unsigned char *)wl->out.buf + 0,
+			      SNAPPYMT_MAGIC_SKIPPABLE);
+		MEM_writeLE32((unsigned char *)wl->out.buf + 4, 8);
+		MEM_writeLE32((unsigned char *)wl->out.buf + 8,
+			      (U32) wl->out.size);
+		/* BR */
+		MEM_writeLE16((unsigned char *)wl->out.buf + 12,
+			      (U16) SNAPPYMT_MAGICNUMBER);
+
+		/* number of 64KB blocks needed for decompression */
+		{
+		U16 hintsize;
+		if (ctx->inputsize > (int)in.size) {
+			hintsize = (U16)(in.size >> 16);
+			hintsize += 1;
+		} else
+			hintsize = ctx->inputsize >> 16;
+		MEM_writeLE16((unsigned char *)wl->out.buf + 14,
+			      hintsize);
+		}
+
+		wl->out.size += 16;
+
+		/* write result */
+		pthread_mutex_lock(&ctx->write_mutex);
+		result = pt_write(ctx, wl);
+		pthread_mutex_unlock(&ctx->write_mutex);
+		if (SNAPPYMT_isError(result))
+			return (void *)result;
+	}
+
+ okay:
+	return 0;
+}
+
+size_t SNAPPYMT_compressCCtx(SNAPPYMT_CCtx *ctx, SNAPPYMT_RdWr_t *rdwr)
+{
+	int t;
+	void *retval_of_thread = 0;
+
+	if (!ctx)
+		return MT_ERROR(compressionParameter_unsupported);
+
+	/* init reading and writing functions */
+	ctx->fn_read = rdwr->fn_read;
+	ctx->fn_write = rdwr->fn_write;
+	ctx->arg_read = rdwr->arg_read;
+	ctx->arg_write = rdwr->arg_write;
+
+	/* start all workers */
+	for (t = 0; t < ctx->threads; t++) {
+		cwork_t *w = &ctx->cwork[t];
+		pthread_create(&w->pthread, NULL, pt_compress, w);
+	}
+
+	/* wait for all workers */
+	for (t = 0; t < ctx->threads; t++) {
+		cwork_t *w = &ctx->cwork[t];
+		void *p = 0;
+		pthread_join(w->pthread, &p);
+		if (p)
+			retval_of_thread = p;
+	}
+
+	/* clean up lists */
+	while (!list_empty(&ctx->writelist_free)) {
+		struct writelist *wl;
+		struct list_head *entry;
+		entry = list_first(&ctx->writelist_free);
+		wl = list_entry(entry, struct writelist, node);
+		free(wl->out.buf);
+		list_del(&wl->node);
+		free(wl);
+	}
+
+	return (size_t) retval_of_thread;
+}
+
+/* returns current uncompressed data size */
+size_t SNAPPYMT_GetInsizeCCtx(SNAPPYMT_CCtx * ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return ctx->insize;
+}
+
+/* returns the current compressed data size */
+size_t SNAPPYMT_GetOutsizeCCtx(SNAPPYMT_CCtx * ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return ctx->outsize;
+}
+
+/* returns the current compressed frames */
+size_t SNAPPYMT_GetFramesCCtx(SNAPPYMT_CCtx * ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return ctx->curframe;
+}
+
+void SNAPPYMT_freeCCtx(SNAPPYMT_CCtx * ctx)
+{
+	if (!ctx)
+		return;
+
+	pthread_mutex_destroy(&ctx->read_mutex);
+	pthread_mutex_destroy(&ctx->write_mutex);
+	free(ctx->cwork);
+	free(ctx);
+	ctx = 0;
+
+	return;
+}
+
+// /* API example */
+// static int ReadData(void *arg, SNAPPYMT_Buffer * in)
+// {
+// 	FILE *fd = (FILE *) arg;
+// 	size_t done = fread(in->buf, 1, in->size, fd);
+// 	in->size = done;
+
+// 	return 0;
+// }
+
+// static int WriteData(void *arg, SNAPPYMT_Buffer * out)
+// {
+// 	FILE *fd = (FILE *) arg;
+// 	ssize_t done = fwrite(out->buf, 1, out->size, fd);
+// 	out->size = done;
+	
+// 	return 0;
+// }
+
+
+// int main(int argc, char *argv[]){
+
+//     FILE *fin, *fout;
+//     fin = fopen(argv[1], "r");
+//     if(!fin){
+//         std::cout << "fin open faild!" << std::endl;
+//     }
+//     fout = fopen(argv[2], "wb");
+//     if(!fout){
+//         std::cout << "fout open faild!" << std::endl;
+//     }
+
+// 	SNAPPYMT_RdWr_t rdwr;
+// 	/* 1) setup read/write functions */
+// 	rdwr.fn_read = ReadData;
+// 	rdwr.fn_write = WriteData;
+// 	rdwr.arg_read = (void *)fin;
+// 	rdwr.arg_write = (void *)fout;
+
+// 	SNAPPYMT_CCtx *cctx = SNAPPYMT_createCCtx(2, 0);
+// 	if (!cctx){
+// 		std::cout << "Allocating compression context failed!" << std::endl;
+// 		return -1;
+// 	}
+
+// 	size_t ret = SNAPPYMT_compressCCtx(cctx, &rdwr);
+// 	if (SNAPPYMT_isError(ret)){
+// 		std::cout << SNAPPYMT_getErrorString(ret) << std::endl;
+// 		return -1;
+// 	}
+
+// 	SNAPPYMT_freeCCtx(cctx);
+
+//     fclose(fin);
+//     fclose(fout);
+
+
+//     return 0;
+// }

--- a/lib/snappy-mt_compress.cc
+++ b/lib/snappy-mt_compress.cc
@@ -9,7 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#define IN_ALLOC_SIZE (1024*1024)
+#define SNAPPY_IN_ALLOC_SIZE (1024*64)
 
 /**
  * multi threaded snappy - multiple workers version
@@ -98,7 +98,7 @@ SNAPPYMT_CCtx *SNAPPYMT_createCCtx(int threads, int level,/*Not use*/
 	if (inputsize)
 		ctx->inputsize = inputsize;
 	else
-		ctx->inputsize = 1024 * 64;  /* 64K frame */
+		ctx->inputsize = SNAPPY_IN_ALLOC_SIZE;  /* 64K frame */
 
 	/* setup ctx */
 	ctx->level = 0; 

--- a/lib/snappy-mt_decompress.cc
+++ b/lib/snappy-mt_decompress.cc
@@ -1,0 +1,572 @@
+#include "../snappy/snappy-c.h"
+#include "snappy-mt.h"
+
+#include "memmt.h"
+#include "threading.h"
+#include "list.h"
+
+#include <iostream>
+#include <stdlib.h>
+#include <string.h>
+
+#define IN_ALLOC_SIZE (1024*1024)
+
+/**
+ * multi threaded snappy - multiple workers version
+ *
+ * - each thread works on his own
+ * - no main thread which does reading and then starting the work
+ * - needs a callback for reading / writing
+ * - each worker does his:
+ *   1) get read mutex and read some input
+ *   2) release read mutex and do compression
+ *   3) get write mutex and write result
+ *   4) begin with step 1 again, until no input
+ */
+
+/* worker for compression */
+typedef struct {
+	SNAPPYMT_DCtx *ctx;
+	pthread_t pthread;
+	SNAPPYMT_Buffer in;
+} cwork_t;
+
+struct writelist {
+	size_t frame;
+	SNAPPYMT_Buffer out;
+	struct list_head node;
+};
+
+struct SNAPPYMT_DCtx_s {
+
+	/* threads: 1..SNAPPYMT_THREAD_MAX */
+	int threads;
+
+	/* should be used for read from input */
+	size_t inputsize;
+
+	/* statistic */
+	size_t insize;
+	size_t outsize;
+	size_t curframe;
+	size_t frames;
+
+	/* threading */
+	cwork_t *cwork;
+
+	/* reading input */
+	pthread_mutex_t read_mutex;
+	fnRead *fn_read;
+	void *arg_read;
+
+	/* writing output */
+	pthread_mutex_t write_mutex;
+	fnWrite *fn_write;
+	void *arg_write;
+
+	/* lists for writing queue */
+	struct list_head writelist_free;
+	struct list_head writelist_busy;
+	struct list_head writelist_done;
+};
+
+/* **************************************
+ * Decompression
+ ****************************************/
+
+SNAPPYMT_DCtx *SNAPPYMT_createDCtx(int threads, int inputsize)
+{
+	SNAPPYMT_DCtx *ctx;
+	int t;
+
+	/* allocate ctx */
+	ctx = (SNAPPYMT_DCtx *) malloc(sizeof(SNAPPYMT_DCtx));
+	if (!ctx)
+		return 0;
+
+	/* check threads value */
+	if (threads < 1 || threads > SNAPPYMT_THREAD_MAX)
+		return 0;
+
+	/* setup ctx */
+	ctx->threads = threads;
+	ctx->insize = 0;
+	ctx->outsize = 0;
+	ctx->frames = 0;
+	ctx->curframe = 0;
+
+	/* will be used for single stream only */
+	if (inputsize)
+		ctx->inputsize = inputsize;
+	else
+		ctx->inputsize = 1024 * 64;	/* 64K buffer */
+
+	pthread_mutex_init(&ctx->read_mutex, NULL);
+	pthread_mutex_init(&ctx->write_mutex, NULL);
+
+	INIT_LIST_HEAD(&ctx->writelist_free);
+	INIT_LIST_HEAD(&ctx->writelist_busy);
+	INIT_LIST_HEAD(&ctx->writelist_done);
+
+	ctx->cwork = (cwork_t *) malloc(sizeof(cwork_t) * threads);
+	if (!ctx->cwork)
+		goto err_cwork;
+
+	for (t = 0; t < threads; t++) {
+		cwork_t *w = &ctx->cwork[t];
+        w->in.allocated = 0;
+        w->in.buf = nullptr;
+        w->in.size = 0;
+		w->ctx = ctx;
+	}
+
+	return ctx;
+
+ err_cwork:
+	free(ctx);
+    ctx = nullptr;
+
+	return 0;
+}
+
+/**
+ * mt_error - return mt lib specific error code
+ */
+static size_t mt_error(int rv)
+{
+	switch (rv) {
+	case -1:
+		return MT_ERROR(read_fail);
+	case -2:
+		return MT_ERROR(canceled);
+	case -3:
+		return MT_ERROR(memory_allocation);
+	}
+
+	/* XXX, some catch all other errors */
+	return MT_ERROR(read_fail);
+}
+
+/**
+ * pt_write - queue for decompressed output
+ */
+static size_t pt_write(SNAPPYMT_DCtx * ctx, struct writelist *wl)
+{
+	struct list_head *entry;
+
+	/* move the entry to the done list */
+	list_move(&wl->node, &ctx->writelist_done);
+
+    /* the entry isn't the currently needed, return...  */
+    if (wl->frame != ctx->curframe)
+		return 0;
+
+ again:
+	/* check, what can be written ... */
+	list_for_each(entry, &ctx->writelist_done) {
+		wl = list_entry(entry, struct writelist, node);
+		if (wl->frame == ctx->curframe) {
+			int rv = ctx->fn_write(ctx->arg_write, &wl->out);
+			if (rv != 0)
+				return mt_error(rv);
+			ctx->outsize += wl->out.size;
+			ctx->curframe++;
+			list_move(entry, &ctx->writelist_free);
+			goto again;
+		}
+	}
+
+	return 0;
+}
+
+/**
+ * pt_read - read compressed output Verify header information
+ */
+static size_t pt_read(SNAPPYMT_DCtx *ctx, SNAPPYMT_Buffer *in, size_t *frame, 
+                      size_t *uncompressed)
+{
+	unsigned char hdrbuf[16];
+	SNAPPYMT_Buffer hdr;
+	int rv;
+
+	/* read skippable frame (12 or 16 bytes) */
+	pthread_mutex_lock(&ctx->read_mutex);
+
+	/* special case, first 4 bytes already read */
+	if (ctx->frames == 0) {
+		hdr.buf = hdrbuf + 4;
+		hdr.size = 12;
+		rv = ctx->fn_read(ctx->arg_read, &hdr);
+		if (rv != 0) {
+			pthread_mutex_unlock(&ctx->read_mutex);
+			return mt_error(rv);
+		}
+		if (hdr.size != 12)
+			goto error_read;
+		hdr.buf = hdrbuf;
+	} else {
+		hdr.buf = hdrbuf;
+		hdr.size = 16;
+		rv = ctx->fn_read(ctx->arg_read, &hdr);
+		if (rv != 0) {
+			pthread_mutex_unlock(&ctx->read_mutex);
+			return mt_error(rv);
+		}
+		/* eof reached ? */
+		if (hdr.size == 0) {
+			pthread_mutex_unlock(&ctx->read_mutex);
+			in->size = 0;
+			return 0;
+		}
+		if (hdr.size != 16)
+			goto error_read;
+		if (MEM_readLE32((unsigned char *)hdr.buf + 0) !=
+		    SNAPPYMT_MAGIC_SKIPPABLE)
+			goto error_data;
+	}
+
+	/* check header data */
+	if (MEM_readLE32((unsigned char *)hdr.buf + 4) != 8)
+		goto error_data;
+	if (MEM_readLE16((unsigned char *)hdr.buf + 12) != SNAPPYMT_MAGICNUMBER)
+		goto error_data;
+
+	// /* get uncompressed size for output buffer */
+	// {
+	// 	U16 hintsize = MEM_readLE16((unsigned char *)hdr.buf + 14);
+	// 	*uncompressed = hintsize << 16;
+	// }
+
+	ctx->insize += 16;
+	/* read new inputsize */
+	{
+		size_t toRead = MEM_readLE32((unsigned char *)hdr.buf + 8);
+		if (in->allocated < toRead) {
+			/* need bigger input buffer */
+			if (in->allocated)
+				in->buf = realloc(in->buf, toRead);
+			else
+				in->buf = malloc(toRead);
+			if (!in->buf)
+				goto error_nomem;
+			in->allocated = toRead;
+		}
+
+		in->size = toRead;
+		rv = ctx->fn_read(ctx->arg_read, in);
+		/* generic read failure! */
+		if (rv != 0) {
+			pthread_mutex_unlock(&ctx->read_mutex);
+			return mt_error(rv);
+		}
+        size_t output_length = 0;
+        if(snappy_validate_compressed_buffer((char *)in->buf, in->size) 
+            != SNAPPY_OK){
+                return MT_ERROR(data_error);
+        }
+        snappy_uncompressed_length((char *)in->buf, in->size, uncompressed);
+        //*uncompressed = output_length;
+		/* needed more bytes! */
+		if (in->size != toRead)
+			goto error_data;
+
+		ctx->insize += in->size;
+	}
+	*frame = ctx->frames++;
+	pthread_mutex_unlock(&ctx->read_mutex);
+
+	/* done, no error */
+	return 0;
+
+ error_data:
+	pthread_mutex_unlock(&ctx->read_mutex);
+	return MT_ERROR(data_error);
+ error_read:
+	pthread_mutex_unlock(&ctx->read_mutex);
+	return MT_ERROR(read_fail);
+ error_nomem:
+	pthread_mutex_unlock(&ctx->read_mutex);
+	return MT_ERROR(memory_allocation);
+}
+
+static void *pt_decompress(void *arg)
+{
+	cwork_t *w = (cwork_t *) arg;
+	SNAPPYMT_Buffer *in = &w->in;
+	SNAPPYMT_DCtx *ctx = w->ctx;
+	size_t result = 0;
+	struct writelist *wl;
+
+	for (;;) {
+		struct list_head *entry;
+		SNAPPYMT_Buffer *out;
+		int rv;
+
+		/* allocate space for new output */
+		pthread_mutex_lock(&ctx->write_mutex);
+		if (!list_empty(&ctx->writelist_free)) {
+			/* take unused entry */
+			entry = list_first(&ctx->writelist_free);
+			wl = list_entry(entry, struct writelist, node);
+			list_move(entry, &ctx->writelist_busy);
+		} else {
+			/* allocate new one */
+			wl = (struct writelist *)
+			    malloc(sizeof(struct writelist));
+			if (!wl) {
+				result = MT_ERROR(memory_allocation);
+				goto error_unlock;
+			}
+			wl->out.buf = 0;
+			wl->out.size = 0;
+			wl->out.allocated = 0;
+			list_add(&wl->node, &ctx->writelist_busy);
+		}
+		pthread_mutex_unlock(&ctx->write_mutex);
+		out = &wl->out;
+
+		/* zero should not happen here! */
+		result = pt_read(ctx, in, &wl->frame, &wl->out.size);
+		if (SNAPPYMT_isError(result)) {
+			list_move(&wl->node, &ctx->writelist_free);
+			goto error_lock;
+		}
+
+		if (in->size == 0)
+			break;
+
+		if (out->allocated < out->size) {
+			if (out->allocated)
+				out->buf = realloc(out->buf, out->size);
+			else
+				out->buf = malloc(out->size);
+			if (!out->buf) {
+				result = MT_ERROR(memory_allocation);
+				goto error_lock;
+			}
+			out->allocated = out->size;
+		}
+
+		rv = snappy_uncompress(static_cast<char*>(in->buf), in->size, 
+                              static_cast<char*>(out->buf), &out->size);
+
+		if (rv != SNAPPY_OK) {
+			result = MT_ERROR(frame_decompress);
+			goto error_lock;
+		}
+
+		/* write result */
+		pthread_mutex_lock(&ctx->write_mutex);
+		result = pt_write(ctx, wl);
+		if (SNAPPYMT_isError(result))
+			goto error_unlock;
+		pthread_mutex_unlock(&ctx->write_mutex);
+	}
+
+	/* everything is okay */
+	pthread_mutex_lock(&ctx->write_mutex);
+	list_move(&wl->node, &ctx->writelist_free);
+	pthread_mutex_unlock(&ctx->write_mutex);
+	if (in->allocated)
+		free(in->buf);
+        in->buf = nullptr;
+        in->allocated = 0;
+        in->size = 0;
+	return 0;
+
+ error_lock:
+	pthread_mutex_lock(&ctx->write_mutex);
+ error_unlock:
+	list_move(&wl->node, &ctx->writelist_free);
+	pthread_mutex_unlock(&ctx->write_mutex);
+	if (in->allocated)
+		free(in->buf);
+        in->buf = nullptr;
+        in->allocated = 0;
+        in->size = 0;
+	return (void *)result;
+}
+
+size_t SNAPPYMT_decompressDCtx(SNAPPYMT_DCtx * ctx, SNAPPYMT_RdWr_t * rdwr)
+{
+	unsigned char buf[4]; // first frame SNAPPYMT_MAGIC_SKIPPABLE
+	int t, rv;
+	cwork_t *w = &ctx->cwork[0];
+	SNAPPYMT_Buffer *in = &w->in;
+	void *retval_of_thread = 0;
+
+	if (!ctx)
+		return MT_ERROR(compressionParameter_unsupported);
+
+	/* init reading and writing functions */
+	ctx->fn_read = rdwr->fn_read;
+	ctx->fn_write = rdwr->fn_write;
+	ctx->arg_read = rdwr->arg_read;
+	ctx->arg_write = rdwr->arg_write;
+
+	/* check for SNAPPYMT_MAGIC_SKIPPABLE  read the first frame
+										   SNAPPYMT_MAGIC_SKIPPABLE*/
+	in->buf = buf;
+	in->size = 4;
+	rv = ctx->fn_read(ctx->arg_read, in);
+	if (rv != 0)
+		return mt_error(rv);
+	if (in->size != 4)
+		return MT_ERROR(data_error);
+
+	/* single threaded with unknown sizes */
+	if (MEM_readLE32(buf) != SNAPPYMT_MAGIC_SKIPPABLE)
+		return MT_ERROR(data_error);
+
+	/* mark unused */
+	in->buf = 0;
+	in->size = 0;
+	in->allocated = 0;
+
+	/* single threaded, but with known sizes */
+	if (ctx->threads == 1) {
+		/* no pthread_create() needed! */
+		void *p = pt_decompress(w);
+		if (p)
+			return (size_t) p;
+		goto okay;
+	}
+
+	/* multi threaded */
+	for (t = 0; t < ctx->threads; t++) {
+		cwork_t *wt = &ctx->cwork[t];
+		wt->in.buf = 0;
+		wt->in.size = 0;
+		wt->in.allocated = 0;
+		pthread_create(&wt->pthread, NULL, pt_decompress, wt);
+	}
+
+	/* wait for all workers */
+	for (t = 0; t < ctx->threads; t++) {
+		cwork_t *wt = &ctx->cwork[t];
+		void *p = 0;
+		pthread_join(wt->pthread, &p);
+		if (p)
+			retval_of_thread = p;
+	}
+
+ okay:
+	/* clean up the buffers */
+	while (!list_empty(&ctx->writelist_free)) {
+		struct writelist *wl;
+		struct list_head *entry;
+		entry = list_first(&ctx->writelist_free);
+		wl = list_entry(entry, struct writelist, node);
+		free(wl->out.buf);
+        wl->out.buf = nullptr;
+        wl->out.allocated = 0;
+        wl->out.size = 0;
+		list_del(&wl->node);
+		free(wl);
+        wl = nullptr;
+	}
+
+	return (size_t) retval_of_thread;
+}
+
+/* returns current uncompressed data size */
+size_t SNAPPYMT_GetInsizeDCtx(SNAPPYMT_DCtx * ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return ctx->insize;
+}
+
+/* returns the current compressed data size */
+size_t SNAPPYMT_GetOutsizeDCtx(SNAPPYMT_DCtx * ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return ctx->outsize;
+}
+
+/* returns the current compressed frames */
+size_t SNAPPYMT_GetFramesDCtx(SNAPPYMT_DCtx * ctx)
+{
+	if (!ctx)
+		return 0;
+
+	return ctx->curframe;
+}
+
+void SNAPPYMT_freeDCtx(SNAPPYMT_DCtx * ctx)
+{
+	if (!ctx)
+		return;
+
+	pthread_mutex_destroy(&ctx->read_mutex);
+	pthread_mutex_destroy(&ctx->write_mutex);
+	free(ctx->cwork);
+    ctx->cwork = nullptr;
+	free(ctx);
+    ctx = nullptr;
+	ctx = 0;
+
+	return;
+}
+
+// /* API example */
+// static int ReadData(void *arg, SNAPPYMT_Buffer * in)
+// {
+// 	FILE *fd = (FILE *) arg;
+// 	size_t done = fread(in->buf, 1, in->size, fd);
+// 	in->size = done;
+
+// 	return 0;
+// }
+
+// static int WriteData(void *arg, SNAPPYMT_Buffer * out)
+// {
+// 	FILE *fd = (FILE *) arg;
+// 	ssize_t done = fwrite(out->buf, 1, out->size, fd);
+// 	out->size = done;
+
+// 	return 0;
+// }
+
+
+// int main(int argc, char *argv[]){
+
+//     FILE *fin, *fout;
+//     fin = fopen(argv[1], "r");
+//     if(!fin){
+//         std::cout << "fin open faild!" << std::endl;
+//     }
+//     fout = fopen(argv[2], "wb");
+//     if(!fout){
+//         std::cout << "fout open faild!" << std::endl;
+//     }
+
+//     SNAPPYMT_RdWr_t rdwr;
+// 	/* 1) setup read/write functions */
+// 	rdwr.fn_read = ReadData;
+// 	rdwr.fn_write = WriteData;
+// 	rdwr.arg_read = (void *)fin;
+// 	rdwr.arg_write = (void *)fout;
+
+// 	SNAPPYMT_DCtx *dctx = SNAPPYMT_createDCtx(2, 0);
+// 	if (!dctx){
+// 		std::cout << "Allocating compression context failed!" << std::endl;
+// 		return -1;
+// 	}
+
+// 	size_t ret = SNAPPYMT_decompressDCtx(dctx, &rdwr);
+// 	if (SNAPPYMT_isError(ret)){
+// 		std::cout << SNAPPYMT_getErrorString(ret) << std::endl;
+// 		return -1;
+// 	}
+
+// 	SNAPPYMT_freeDCtx(dctx);
+
+//     fclose(fin);
+//     fclose(fout);
+
+//     return 0;
+// }

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -7,6 +7,7 @@
 BRO_VER	= "v1.0.7"
 LIZ_VER	= "v1.0"
 LZ4_VER	= "v1.8.3"
+LZ5_VER	= "v1.5"
 ZSTD_VER= "v1.4.5"
 SNAP_VER= "1.1.8"
 # uncomment, for cross compiling or windows binaries
@@ -40,9 +41,9 @@ CXXFLAGS	+= -std=gnu++11
 #CFLAGS += -march=native 
 LDFLAGS	= $(WIN_LDFLAGS) -lpthread
 
-	#   lz5-mt$(EXTENSION) 
 PRGS	= lizard-mt$(EXTENSION) \
 	  lz4-mt$(EXTENSION) \
+	  lz5-mt$(EXTENSION) \
 	  brotli-mt$(EXTENSION) \
 	  zstd-mt$(EXTENSION) \
 	  snappy-mt$(EXTENSION) 
@@ -59,6 +60,8 @@ LIBLIZ	= $(COMMON) $(ZSTDMTDIR)/lizard-mt_common.c $(ZSTDMTDIR)/lizard-mt_compre
 	  $(ZSTDMTDIR)/lizard-mt_decompress.c lizard-mt.c
 LIBLZ4	= $(COMMON) $(ZSTDMTDIR)/lz4-mt_common.c $(ZSTDMTDIR)/lz4-mt_compress.c \
 	  $(ZSTDMTDIR)/lz4-mt_decompress.c lz4-mt.c
+LIBLZ5	= $(COMMON) $(ZSTDMTDIR)/lz5-mt_common.c $(ZSTDMTDIR)/lz5-mt_compress.c \
+	  $(ZSTDMTDIR)/lz5-mt_decompress.c lz5-mt.c
 LIBZSTD	= $(COMMON) $(ZSTDMTDIR)/zstd-mt_common.c $(ZSTDMTDIR)/zstd-mt_compress.c \
 	  $(ZSTDMTDIR)/zstd-mt_decompress.c zstd-mt.c
 LIBSNAP	= $(COMMON) $(ZSTDMTDIR)/snappy-mt_common.cc $(ZSTDMTDIR)/snappy-mt_compress.cc \
@@ -96,6 +99,11 @@ CF_BRO	= $(CFLAGS) -I$(BRODIR)/include
 LZ4DIR	= lz4/lib
 LIBLZ4	+= $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhash.c
 CF_LZ4	= $(CFLAGS) -Ilz4/lib
+
+# LZ5, https://github.com/inikep/lz5
+LZ5DIR	= lz5/lib
+LIBLZ5	+= $(LZ5DIR)/lz5.c $(LZ5DIR)/lz5frame.c $(LZ5DIR)/lz5hc.c $(LZ5DIR)/xxhash.c
+CF_LZ5	= $(CFLAGS) -Ilz5/lib
 
 # Lizard, https://github.com/inikep/lizard
 LIZDIR	= lizard/lib
@@ -173,6 +181,12 @@ lz4-mt$(EXTENSION):
 	$(LN) -s $@ un$@
 	$(LN) -s $@ lz4cat-mt
 
+lz5-mt$(EXTENSION):
+	$(CC) $(CF_LZ5) -DVERSION='$(LZ5_VER)' -o $@ $(LIBLZ5) $(LDFLAGS)
+	$(STRIP) $(SFLAGS) $@
+	$(LN) -s $@ un$@
+	$(LN) -s $@ lz5cat-mt
+
 zstd-mt$(EXTENSION):
 	$(CC) $(CF_ZSTD) -DVERSION='$(ZSTD_VER)' -o $@ $(LIBZSTD) $(LDFLAGS)
 	$(STRIP) $(SFLAGS) $@
@@ -187,6 +201,7 @@ snappy-mt$(EXTENSION):
 
 loadsource:
 	test -d lz4    || git clone https://github.com/Cyan4973/lz4  -b $(LZ4_VER)  --depth=1 lz4
+	test -d lz5    || git clone https://github.com/inikep/lz5    -b $(LZ5_VER)  --depth=1 lz5
 	test -d zstd   || git clone https://github.com/facebook/zstd -b $(ZSTD_VER) --depth=1 zstd
 	test -d lizard || git clone https://github.com/inikep/lizard -b $(LIZ_VER)  --depth=1 lizard
 	test -d brotli || git clone https://github.com/google/brotli -b $(BRO_VER)  --depth=1 brotli

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -7,7 +7,7 @@
 BRO_VER	= "v1.0.7"
 LIZ_VER	= "v1.0"
 LZ4_VER	= "v1.8.3"
-ZSTD_VER= "v1.4.4"
+ZSTD_VER= "v1.4.5"
 SNAP_VER= "1.1.8"
 # uncomment, for cross compiling or windows binaries
 #WIN_LDFLAGS	= -lwinmm -lpsapi

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -129,6 +129,9 @@ LIBZSTD	+= $(ZSTDDIR)/common/debug.c \
 	  $(ZSTDDIR)/compress/zstd_lazy.c \
 	  $(ZSTDDIR)/compress/zstd_ldm.c \
 	  $(ZSTDDIR)/compress/zstd_opt.c \
+	  $(ZSTDDIR)/compress/zstd_compress_sequences.c \
+	  $(ZSTDDIR)/compress/zstd_compress_superblock.c \
+	  $(ZSTDDIR)/compress/zstd_compress_literals.c \
 	  $(ZSTDDIR)/decompress/huf_decompress.c \
 	  $(ZSTDDIR)/decompress/zstd_ddict.c \
 	  $(ZSTDDIR)/decompress/zstd_decompress.c \

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -34,16 +34,16 @@ CFLAGS	+= -O3
 CXXFLAGS	= -W -pthread -Wall -pipe
 CXXFLAGS	+= -fomit-frame-pointer
 CXXFLAGS	+= -O3
-CXXFLAGS	+= -std=c++11 
+CXXFLAGS	+= -std=gnu++11 
 #CFLAGS	+= -flto
 #CFLAGS += -DDEBUGME
 #CFLAGS += -g
-#CFLAGS += -march=native
+#CFLAGS += -march=native 
 LDFLAGS	= $(WIN_LDFLAGS) -lpthread
 
+	#   lz5-mt$(EXTENSION) 
 PRGS	= lizard-mt$(EXTENSION) \
 	  lz4-mt$(EXTENSION) \
-	  lz5-mt$(EXTENSION) \
 	  brotli-mt$(EXTENSION) \
 	  zstd-mt$(EXTENSION) \
 	  snappy-mt$(EXTENSION) 
@@ -60,8 +60,8 @@ LIBLIZ	= $(COMMON) $(ZSTDMTDIR)/lizard-mt_common.c $(ZSTDMTDIR)/lizard-mt_compre
 	  $(ZSTDMTDIR)/lizard-mt_decompress.c lizard-mt.c
 LIBLZ4	= $(COMMON) $(ZSTDMTDIR)/lz4-mt_common.c $(ZSTDMTDIR)/lz4-mt_compress.c \
 	  $(ZSTDMTDIR)/lz4-mt_decompress.c lz4-mt.c
-LIBLZ5	= $(COMMON) $(ZSTDMTDIR)/lz5-mt_common.c $(ZSTDMTDIR)/lz5-mt_compress.c \
-	  $(ZSTDMTDIR)/lz5-mt_decompress.c lz5-mt.c
+# LIBLZ5	= $(COMMON) $(ZSTDMTDIR)/lz5-mt_common.c $(ZSTDMTDIR)/lz5-mt_compress.c \
+# 	  $(ZSTDMTDIR)/lz5-mt_decompress.c lz5-mt.c
 LIBZSTD	= $(COMMON) $(ZSTDMTDIR)/zstd-mt_common.c $(ZSTDMTDIR)/zstd-mt_compress.c \
 	  $(ZSTDMTDIR)/zstd-mt_decompress.c zstd-mt.c
 LIBSNAP	= $(COMMON) $(ZSTDMTDIR)/snappy-mt_common.cc $(ZSTDMTDIR)/snappy-mt_compress.cc \
@@ -101,9 +101,9 @@ LIBLZ4	+= $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhas
 CF_LZ4	= $(CFLAGS) -Ilz4/lib
 
 # LZ5, https://github.com/inikep/lz5
-LZ5DIR	= lz5/lib
-LIBLZ5	+= $(LZ5DIR)/lz5.c $(LZ5DIR)/lz5frame.c $(LZ5DIR)/lz5hc.c $(LZ5DIR)/xxhash.c
-CF_LZ5	= $(CFLAGS) -Ilz5/lib
+# LZ5DIR	= lz5/lib
+# LIBLZ5	+= $(LZ5DIR)/lz5.c $(LZ5DIR)/lz5frame.c $(LZ5DIR)/lz5hc.c $(LZ5DIR)/xxhash.c
+# CF_LZ5	= $(CFLAGS) -Ilz5/lib
 
 # Lizard, https://github.com/inikep/lizard
 LIZDIR	= lizard/lib
@@ -137,6 +137,9 @@ LIBZSTD	+= $(ZSTDDIR)/common/debug.c \
 	  $(ZSTDDIR)/compress/zstd_lazy.c \
 	  $(ZSTDDIR)/compress/zstd_ldm.c \
 	  $(ZSTDDIR)/compress/zstd_opt.c \
+	  $(ZSTDDIR)/compress/zstd_compress_sequences.c \
+	  $(ZSTDDIR)/compress/zstd_compress_literals.c \
+	  $(ZSTDDIR)/compress/zstd_compress_superblock.c \
 	  $(ZSTDDIR)/decompress/huf_decompress.c \
 	  $(ZSTDDIR)/decompress/zstd_ddict.c \
 	  $(ZSTDDIR)/decompress/zstd_decompress.c \
@@ -178,11 +181,11 @@ lz4-mt$(EXTENSION):
 	$(LN) -s $@ un$@
 	$(LN) -s $@ lz4cat-mt
 
-lz5-mt$(EXTENSION):
-	$(CC) $(CF_LZ5) -DVERSION='$(LZ5_VER)' -o $@ $(LIBLZ5) $(LDFLAGS)
-	$(STRIP) $(SFLAGS) $@
-	$(LN) -s $@ un$@
-	$(LN) -s $@ lz5cat-mt
+# lz5-mt$(EXTENSION):
+# 	$(CC) $(CF_LZ5) -DVERSION='$(LZ5_VER)' -o $@ $(LIBLZ5) $(LDFLAGS)
+# 	$(STRIP) $(SFLAGS) $@
+# 	$(LN) -s $@ un$@
+# 	$(LN) -s $@ lz5cat-mt
 
 zstd-mt$(EXTENSION):
 	$(CC) $(CF_ZSTD) -DVERSION='$(ZSTD_VER)' -o $@ $(LIBZSTD) $(LDFLAGS)
@@ -198,7 +201,7 @@ snappy-mt$(EXTENSION):
 
 loadsource:
 	test -d lz4    || git clone https://github.com/Cyan4973/lz4  -b $(LZ4_VER)  --depth=1 lz4
-	test -d lz5    || git clone https://github.com/inikep/lz5    -b $(LZ5_VER)  --depth=1 lz5
+	# test -d lz5    || git clone https://github.com/inikep/lz5    -b $(LZ5_VER)  --depth=1 lz5
 	test -d zstd   || git clone https://github.com/facebook/zstd -b $(ZSTD_VER) --depth=1 zstd
 	test -d lizard || git clone https://github.com/inikep/lizard -b $(LIZ_VER)  --depth=1 lizard
 	test -d brotli || git clone https://github.com/google/brotli -b $(BRO_VER)  --depth=1 brotli

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -7,8 +7,7 @@
 BRO_VER	= "v1.0.7"
 LIZ_VER	= "v1.0"
 LZ4_VER	= "v1.8.3"
-LZ5_VER	= "v1.5"
-ZSTD_VER= "v1.3.8"
+ZSTD_VER= "v1.4.4"
 SNAP_VER= "1.1.8"
 # uncomment, for cross compiling or windows binaries
 #WIN_LDFLAGS	= -lwinmm -lpsapi
@@ -60,8 +59,6 @@ LIBLIZ	= $(COMMON) $(ZSTDMTDIR)/lizard-mt_common.c $(ZSTDMTDIR)/lizard-mt_compre
 	  $(ZSTDMTDIR)/lizard-mt_decompress.c lizard-mt.c
 LIBLZ4	= $(COMMON) $(ZSTDMTDIR)/lz4-mt_common.c $(ZSTDMTDIR)/lz4-mt_compress.c \
 	  $(ZSTDMTDIR)/lz4-mt_decompress.c lz4-mt.c
-# LIBLZ5	= $(COMMON) $(ZSTDMTDIR)/lz5-mt_common.c $(ZSTDMTDIR)/lz5-mt_compress.c \
-# 	  $(ZSTDMTDIR)/lz5-mt_decompress.c lz5-mt.c
 LIBZSTD	= $(COMMON) $(ZSTDMTDIR)/zstd-mt_common.c $(ZSTDMTDIR)/zstd-mt_compress.c \
 	  $(ZSTDMTDIR)/zstd-mt_decompress.c zstd-mt.c
 LIBSNAP	= $(COMMON) $(ZSTDMTDIR)/snappy-mt_common.cc $(ZSTDMTDIR)/snappy-mt_compress.cc \
@@ -99,11 +96,6 @@ CF_BRO	= $(CFLAGS) -I$(BRODIR)/include
 LZ4DIR	= lz4/lib
 LIBLZ4	+= $(LZ4DIR)/lz4.c $(LZ4DIR)/lz4frame.c $(LZ4DIR)/lz4hc.c $(LZ4DIR)/xxhash.c
 CF_LZ4	= $(CFLAGS) -Ilz4/lib
-
-# LZ5, https://github.com/inikep/lz5
-# LZ5DIR	= lz5/lib
-# LIBLZ5	+= $(LZ5DIR)/lz5.c $(LZ5DIR)/lz5frame.c $(LZ5DIR)/lz5hc.c $(LZ5DIR)/xxhash.c
-# CF_LZ5	= $(CFLAGS) -Ilz5/lib
 
 # Lizard, https://github.com/inikep/lizard
 LIZDIR	= lizard/lib
@@ -181,12 +173,6 @@ lz4-mt$(EXTENSION):
 	$(LN) -s $@ un$@
 	$(LN) -s $@ lz4cat-mt
 
-# lz5-mt$(EXTENSION):
-# 	$(CC) $(CF_LZ5) -DVERSION='$(LZ5_VER)' -o $@ $(LIBLZ5) $(LDFLAGS)
-# 	$(STRIP) $(SFLAGS) $@
-# 	$(LN) -s $@ un$@
-# 	$(LN) -s $@ lz5cat-mt
-
 zstd-mt$(EXTENSION):
 	$(CC) $(CF_ZSTD) -DVERSION='$(ZSTD_VER)' -o $@ $(LIBZSTD) $(LDFLAGS)
 	$(STRIP) $(SFLAGS) $@
@@ -201,7 +187,6 @@ snappy-mt$(EXTENSION):
 
 loadsource:
 	test -d lz4    || git clone https://github.com/Cyan4973/lz4  -b $(LZ4_VER)  --depth=1 lz4
-	# test -d lz5    || git clone https://github.com/inikep/lz5    -b $(LZ5_VER)  --depth=1 lz5
 	test -d zstd   || git clone https://github.com/facebook/zstd -b $(ZSTD_VER) --depth=1 zstd
 	test -d lizard || git clone https://github.com/inikep/lizard -b $(LIZ_VER)  --depth=1 lizard
 	test -d brotli || git clone https://github.com/google/brotli -b $(BRO_VER)  --depth=1 brotli

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -8,8 +8,8 @@ BRO_VER	= "v1.0.7"
 LIZ_VER	= "v1.0"
 LZ4_VER	= "v1.8.3"
 LZ5_VER	= "v1.5"
-ZSTD_VER= "v1.3.8"
-
+ZSTD_VER= "v1.4.4"
+SNAP_VER= "1.1.8"
 # uncomment, for cross compiling or windows binaries
 #WIN_LDFLAGS	= -lwinmm -lpsapi
 #CROSS		= i686-w64-mingw32-
@@ -22,13 +22,19 @@ LN	= ln -sf
 #CC	= $(CROSS)musl-gcc
 #CC	= $(CROSS)clang
 CC	= $(CROSS)gcc
+CXX	= $(CROSS)g++
 RANLIB	= $(CROSS)ranlib
 STRIP	= $(CROSS)strip
-SFLAGS	= -R .note -R .comment
+#SFLAGS	= -R .note -R .comment
+SFLAGS	= #-R .note .comment
 
 CFLAGS	= -W -pthread -Wall -pipe
 CFLAGS	+= -fomit-frame-pointer
 CFLAGS	+= -O3
+CXXFLAGS	= -W -pthread -Wall -pipe
+CXXFLAGS	+= -fomit-frame-pointer
+CXXFLAGS	+= -O3
+CXXFLAGS	+= -std=c++11 
 #CFLAGS	+= -flto
 #CFLAGS += -DDEBUGME
 #CFLAGS += -g
@@ -39,7 +45,8 @@ PRGS	= lizard-mt$(EXTENSION) \
 	  lz4-mt$(EXTENSION) \
 	  lz5-mt$(EXTENSION) \
 	  brotli-mt$(EXTENSION) \
-	  zstd-mt$(EXTENSION)
+	  zstd-mt$(EXTENSION) \
+	  snappy-mt$(EXTENSION) 
 
 all:	loadsource $(PRGS)
 again:	clean $(PRGS)
@@ -57,6 +64,8 @@ LIBLZ5	= $(COMMON) $(ZSTDMTDIR)/lz5-mt_common.c $(ZSTDMTDIR)/lz5-mt_compress.c \
 	  $(ZSTDMTDIR)/lz5-mt_decompress.c lz5-mt.c
 LIBZSTD	= $(COMMON) $(ZSTDMTDIR)/zstd-mt_common.c $(ZSTDMTDIR)/zstd-mt_compress.c \
 	  $(ZSTDMTDIR)/zstd-mt_decompress.c zstd-mt.c
+LIBSNAP	= $(COMMON) $(ZSTDMTDIR)/snappy-mt_common.cc $(ZSTDMTDIR)/snappy-mt_compress.cc \
+	  $(ZSTDMTDIR)/snappy-mt_decompress.cc snappy-mt.cc
 
 # Brotli, https://github.com/google/brotli
 BRODIR	= brotli/c
@@ -139,8 +148,17 @@ LIBZSTD	+= $(ZSTDDIR)/common/debug.c \
 CF_ZSTD	= $(CFLAGS) -I$(ZSTDDIR) -I$(ZSTDDIR)/common -I$(ZSTDDIR)/compress \
 	  -I$(ZSTDDIR)/decompress -I$(ZSTDDIR)/legacy
 
+# snappy, https://github.com/google/snappy
+SNAPDIR	= snappy
+LIBSNAP	+= $(SNAPDIR)/snappy-c.cc \
+	  $(SNAPDIR)/snappy-sinksource.cc \
+	  $(SNAPDIR)/snappy-stubs-internal.cc \
+	  $(SNAPDIR)/snappy.cc 
+CF_SNAP	= $(CXXFLAGS) -I$(SNAPDIR)
+
 # append lib include directory
 CFLAGS	+= -I. -I$(ZSTDMTDIR)
+CXXFLAGS	+= -I. -I$(ZSTDMTDIR)
 
 brotli-mt$(EXTENSION):
 	$(CC) $(CF_BRO) -DVERSION='$(BRO_VER)' -o $@ $(LIBBRO) $(LDFLAGS) -lm
@@ -167,10 +185,16 @@ lz5-mt$(EXTENSION):
 	$(LN) -s $@ lz5cat-mt
 
 zstd-mt$(EXTENSION):
-	$(CC) $(CF_ZSTD) $(CDFLAGS) -DVERSION='$(ZSTD_VER)' -o $@ $(LIBZSTD) $(LDFLAGS)
+	$(CC) $(CF_ZSTD) -DVERSION='$(ZSTD_VER)' -o $@ $(LIBZSTD) $(LDFLAGS)
 	$(STRIP) $(SFLAGS) $@
 	$(LN) $@ un$@
 	$(LN) $@ zstdcat-mt
+
+snappy-mt$(EXTENSION):
+	$(CXX) $(CF_SNAP) -DVERSION='$(SNAP_VER)' -o $@ $(LIBSNAP) $(LDFLAGS)
+	$(STRIP) $(SFLAGS) $@
+	$(LN) $@ un$@
+	$(LN) $@ snappycat-mt
 
 loadsource:
 	test -d lz4    || git clone https://github.com/Cyan4973/lz4  -b $(LZ4_VER)  --depth=1 lz4
@@ -178,14 +202,16 @@ loadsource:
 	test -d zstd   || git clone https://github.com/facebook/zstd -b $(ZSTD_VER) --depth=1 zstd
 	test -d lizard || git clone https://github.com/inikep/lizard -b $(LIZ_VER)  --depth=1 lizard
 	test -d brotli || git clone https://github.com/google/brotli -b $(BRO_VER)  --depth=1 brotli
+	test -d snappy || git clone https://github.com/google/snappy -b $(SNAP_VER)  --depth=1 snappy
+	cd snappy && cmake CMakeLists.txt && cd ..
 
 install:
 	echo TODO ;)
 
 clean:
 	rm -f $(PRGS)
-	rm -f unbrotli-mt unlizard-mt unlz4-mt unlz5-mt unzstd-mt
-	rm -f brotlicat-mt lizardcat-mt lz4cat-mt lz5cat-mt zstdcat-mt
+	rm -f unbrotli-mt unlizard-mt unlz4-mt unlz5-mt unzstd-mt unsnappy-mt
+	rm -f brotlicat-mt lizardcat-mt lz4cat-mt lz5cat-mt zstdcat-mt  snappycat-mt
 
 mrproper: clean
-	rm -rf brotli lizard lz4 lz5 zstd
+	rm -rf brotli lizard lz4 lz5 zstd snappy

--- a/programs/main.c
+++ b/programs/main.c
@@ -186,7 +186,7 @@ static int WriteData(void *arg, MT_Buffer * out)
 
 	/* generate crc32 of uncompressed file */
 	if (opt_mode == MODE_LIST && opt_verbose > 1)
-		crc = crc32(out->buf, out->size, crc);
+		crc = crc32((unsigned char*)out->buf, out->size, crc);
 	/* printf("crc for %zu bytes, %8x\n", out->size, crc); */
 
 	out->size = done;
@@ -311,7 +311,7 @@ static char *add_suffix(const char *filename)
 {
 	int flen = strlen(filename);
 	int xlen = strlen(opt_suffix);
-	char *newname = malloc(flen + xlen + 1);
+	char *newname = (char *)malloc(flen + xlen + 1);
 
 	if (!newname)
 		panic("nomem!");
@@ -326,7 +326,7 @@ static char *remove_suffix(const char *filename)
 {
 	int flen = strlen(filename);
 	int xlen = strlen(opt_suffix);
-	char *newname = malloc(flen + xlen + 5);
+	char *newname = (char *)malloc(flen + xlen + 5);
 
 	if (!newname)
 		panic("nomem!");

--- a/programs/snappy-mt.cc
+++ b/programs/snappy-mt.cc
@@ -1,0 +1,39 @@
+
+/**
+ */
+
+#include "snappy-mt.h"
+
+#define METHOD   "snappy"
+#define PROGNAME "snappy-mt"
+#define UNZIP    "unsnappy-mt"
+#define ZCAT     "snappycat-mt"
+#define SUFFIX   ".snp"
+
+#define LEVEL_DEF          0
+#define LEVEL_MIN          0
+#define LEVEL_MAX          1
+#define THREAD_MAX         SNAPPYMT_THREAD_MAX
+
+#define MT_isError         SNAPPYMT_isError
+#define MT_getErrorString  SNAPPYMT_getErrorString
+#define MT_Buffer          SNAPPYMT_Buffer
+#define MT_RdWr_t          SNAPPYMT_RdWr_t
+
+#define MT_CCtx            SNAPPYMT_CCtx
+#define MT_createCCtx      SNAPPYMT_createCCtx
+#define MT_compressCCtx    SNAPPYMT_compressCCtx
+#define MT_GetFramesCCtx   SNAPPYMT_GetFramesCCtx
+#define MT_GetInsizeCCtx   SNAPPYMT_GetInsizeCCtx
+#define MT_GetOutsizeCCtx  SNAPPYMT_GetOutsizeCCtx
+#define MT_freeCCtx        SNAPPYMT_freeCCtx
+
+#define MT_DCtx            SNAPPYMT_DCtx
+#define MT_createDCtx      SNAPPYMT_createDCtx
+#define MT_decompressDCtx  SNAPPYMT_decompressDCtx
+#define MT_GetFramesDCtx   SNAPPYMT_GetFramesDCtx
+#define MT_GetInsizeDCtx   SNAPPYMT_GetInsizeDCtx
+#define MT_GetOutsizeDCtx  SNAPPYMT_GetOutsizeDCtx
+#define MT_freeDCtx        SNAPPYMT_freeDCtx
+
+#include "main.c"


### PR DESCRIPTION
lz5 and Lizard are now merged, only Lizard. So I deleted lz5. And updated zstd to the latest version 1.4.5.
Snappy is very fast.On a single core of a Core i7 processor in 64-bit mode, Snappy compresses at about 250 MB/sec or more and decompresses at about 500 MB/sec or more. Multithreading can achieve better performance. so I added snappy method.