### PR TITLE
keep files decompressed to stdout

### DIFF
--- a/programs/main.c
+++ b/programs/main.c
@@ -742,6 +742,7 @@ int main(int argc, char **argv)
 
 		case 'c':	/* force to stdout */
 			opt_stdout = 1;
+			opt_keep = 1;
 			break;
 
 		case 'd':	/* mode = decompress */


### PR DESCRIPTION
Image my surprise when decompressing file to stdout input had been removed. Fortunately it wasn't file I couldn't reodwnload but still this is not standard behaviour. Gzip, nor bzip wouldn't do that.
I think it should be kept as it's not what anyone expects as no other compressor does that.
