### PR TITLE
preserve file attributes

### DIFF
--- a/programs/platform.h
+++ b/programs/platform.h
@@ -30,6 +30,7 @@ extern "C" {
 #include <stdio.h>
 #include <errno.h>
 #include <time.h>
+#include <utime.h>
 
 extern int getcpucount(void);
 


### PR DESCRIPTION
Preserve file attributes, and modification time

It means to Preserve file attributes, and modification time as gzip/bzip do. For some reason the modification doesn't get preserved although in my [test](https://paste.ee/p/8BSD8) it worked. Even changing it before closing file worked ([test/2](https://paste.ee/p/75jMu)). Maybe someone can spot the problem and fix that.
