### PR TITLE
patch undefined fchmod in windows

### DIFF
--- a/programs/platform.h
+++ b/programs/platform.h
@@ -44,6 +44,8 @@ extern int getcpucount(void);
 #include <timezoneapi.h> /* FileTimeToSystemTime() */
 #include <psapi.h> /* GetProcessMemoryInfo() */
 #include <io.h> /* _isatty */
+#define fchmod(x,y) 0
+#define fchown(x,y,z) 0
 
 #define DEVNULL "NUL"
 #define PATH_SEPERATOR '\\'


### PR DESCRIPTION
Trying to compile it under windows I got `undefined reference to 'fchmod'`. I was surprised to discover that windows doesn't have that function, so I patched that with 0, so it didn't generate errors, though it won't work there.
Patch come from Lzip where I got the idea of preserving file attributes in first place. If it's good enough there, it can be here.