### PR TITLE
default blocksize to 2xWlog

### DIFF
--- a/lib/zstd-mt_compress.c
+++ b/lib/zstd-mt_compress.c
@@ -123,7 +123,7 @@ ZSTDCB_CCtx *ZSTDCB_createCCtx(int threads, int level, int inputsize)
 			23, 23, 23, 23, 25, /* 16 - 20 */
 			26, 27
 		};
-		ctx->inputsize = 1 << (windowLog[level - 1] + 1);
+		ctx->inputsize = 1 << (windowLog[level] + 1);
 	}
 
 	/* setup ctx */


### PR DESCRIPTION
Current block size defaults to `1 << (WindowLog[level - 1] + 1)`. This is mostly equivalent to 2xWindowLog with some exceptions. And these exceptions are not justified IMO.
There is no reason in making some levels worse, because that's what it results. Let's make it simple and default to 2xWindowLog.
