### PR TITLE
and new line to version message

### DIFF
--- a/programs/main.c
+++ b/programs/main.c
@@ -83,6 +83,7 @@ static void version(int quit)
 {
 	printf(" %s using libzstdmt v0.8, using %s %s"
 		"\n Copyright (c) 2016 - 2024 Tino Reichardt",
+		"\n",
 		progname, METHOD, VERSION);
 
 	if (quit)


### PR DESCRIPTION
As there is no new line at the end of version message it mixes up with command prompt like this:

```
$ zstd-mt -V
 zstd-mt using libzstdmt v0.8, using zstd v1.5.6
 Copyright (c) 2016 - 2024 Tino Reichardtuser@host: ~/ $
```
To prevent it '\n' is added.
